### PR TITLE
Fix header not found when compiling with modern GNU C library

### DIFF
--- a/src/utility/system.C
+++ b/src/utility/system.C
@@ -34,7 +34,11 @@
 #endif
 
 #if !defined(__CYGWIN__) && !defined(_WIN32)
+#if defined(__linux__)
+#include <linux/sysctl.h>
+#else
 #include <sys/sysctl.h>
+#endif
 #endif
 
 


### PR DESCRIPTION
The error message from compiler:
> utility/system.C:38:10: fatal error: sys/sysctl.h: No such file or directory
   38 | #include <sys/sysctl.h>

From GNU C library 2.32 release news:
> * The deprecated <sys/sysctl.h> header and the sysctl function have been
  removed.

https://sourceware.org/pipermail/libc-announce/2020/000029.html