### PR TITLE
Add license information for parasail

### DIFF
--- a/README.licenses
+++ b/README.licenses
@@ -193,3 +193,52 @@ For SSW Library (align-ssw.C and align-ssw.H):
   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+--
+For parasail:
+
+  Pairwise Sequence Alignment Library (parasail)
+
+  Copyright (c) 2015, Battelle Memorial Institute
+
+  1.  Battelle Memorial Institute (hereinafter Battelle) hereby grants
+      permission to any person or entity lawfully obtaining a copy of this
+      software and associated documentation files (hereinafter “the
+      Software”) to redistribute and use the Software in source and binary
+      forms, with or without modification.  Such person or entity may use,
+      copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and may permit others to do so, subject to
+      the following conditions:
+
+      - Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimers.
+
+      - Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in
+        the documentation and/or other materials provided with the
+        distribution.
+
+      - Other than as used herein, neither the name Battelle Memorial
+        Institute or Battelle may be used in any form whatsoever without
+        the express written consent of Battelle.
+
+      - Redistributions of the software in any form, and publications
+        based on work performed using the software should include the
+        following citation as a reference:
+
+      Daily, Jeff. (2016). Parasail: SIMD C library for global,
+      semi-global, and local pairwise sequence alignments. *BMC
+      Bioinformatics*, 17(1), 1-11.  doi:10.1186/s12859-016-0930-z
+
+  2.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+      "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+      LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+      FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BATTELLE
+      OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+      SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+      LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+      USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+      ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+      OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+      OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+      SUCH DAMAGE.
+


### PR DESCRIPTION
Source:
 https://github.com/jeffdaily/parasail/blob/2fee307b6209d4a26be144f3e008de0e02e1c8db/LICENSE.md

Hi,

I noticed that `README.licenses` doesn't include the (BSD-2-Clause-like with additional conditions) license found in parasail's repository.
Please let me know if there are further changes needed for this to PR to be included.

Cheers,
Marcel