### PR TITLE
fix array size parameter

### DIFF
--- a/src/datastructures/arrays-v1.H
+++ b/src/datastructures/arrays-v1.H
@@ -165,8 +165,19 @@ duplicateArray(TT*& to, LL &toLen, LL &toMax, TT const *fr, LL frLen, LL frMax=0
 }
 
 
-//  Set the array size to 'newMax'.
-//  No guards, the array will ALWAYS be reallocated.
+
+//
+//  Change the size of an array.  The array is ALWAYS reallocated.
+//
+//  Elements        0 .. arrayLen are copied from the old to the new array.
+//  Elements arrayLen .. newMax   can be (optionally) set to zero.
+//
+//  WARNING: If arrayLen is larger than newMax, only the first newMax
+//           elements are copied.  arrayLen IS NOT modified to reflect this.
+//
+//  Output parameter arrayMax is set to newMax; arrayMax is not otherwise used.
+//
+//  WARNING: Use increaseArray() or resizeArray() instead of this function.
 //
 template<typename TT, typename LL>
 void
@@ -195,96 +206,121 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
 
 
 
+//
 //  Ensure that there is enough space to hold one more element in the array.
-//  Increase the array by 'moreSpace' if needed.
+//  Increase the array by 'moreSpace' elements if needed.
 //
-//  With the array used as a stack, a call of
-//    increaseArray(arr, arrLen, arrMax, 32)
-//  will allocate 32 more elements if arrLen == arrMax, and do nothing
-//  otherwise.  After the call, array element arr[arrLen] is guaranteed to
-//  exist.  If arrLen > arrMax, see below.
+//  With the array used as a stack, where elements are added to the tail:
 //
-//  With the array used for random access, a call of
+//    while (...) {
+//      increaseArray(arr, arrLen, arrMax, 32)
+//      arr[arrLen++] = ...
+//    }
+//
+//  will allocate 32 more elements to the array when arrLen == arrMax, and do
+//  nothing otherwise.  After the call, array element arr[arrLen] is
+//  guaranteed to exist.
+//
+//  Likewise, for random-access, element arr[idx] is guaranteed to exist
+//  after the call:
+//
+//    idx = ...
 //    increaseArray(arr, idx, arrMax, 32)
-//  will do nothing if idx < arrMax, and resize the array to have idx+32
-//  elements otherwise.
-//  
-//  In both cases, if 'moreSpace' is 0, it is reset to 1.
+//    arr[idx] = ...
 //
-//  If the array is reallocated, the contents of the entire array are copied
-//  to the new space.  New elements are NOT cleared to zero; override op as
-//  desired.
+//  will do nothing if idx < arrMax, but will resize the array to have idx+32
+//  elements otherwise.  In this case, the 'length' of the array is not
+//  tracked, we only know that the array has arrMax allocated elements (and
+//  you probably want to set op=_raAct::copyDataClearNew to initialize any
+//  newly allocated elements to zero).
+//  
+//  If the array is reallocated, the contents of the entire array (0
+//  .. arrayMax) are copied to the new space.  By default, new elements are
+//  NOT cleared to zero; set 'op' to '_raAct::copyDataClearNew' to enable.
+//
+//  'moreSpace' must be at least 1.
 //
 template<typename TT, typename LL>
 void
 increaseArray(TT*& array, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
+  uint64  oldMax = arrayMax;
   uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
 
   if (idx < arrayMax)
     return;
 
-  setArraySize(array, idx, arrayMax, newMax, op);
+  setArraySize(array, oldMax, arrayMax, newMax, op);
 }
 
 
 template<typename T1, typename T2, typename LL>
 void
 increaseArrayPair(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
+  uint64  oldMax = arrayMax;
   uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
 
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, idx, arrayMax, newMax, op);
-  setArraySize(array2, idx, arrayMax, newMax, op);
+  setArraySize(array1, oldMax, arrayMax, newMax, op);
+  setArraySize(array2, oldMax, arrayMax, newMax, op);
 }
 
 
 template<typename T1, typename T2, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
+  uint64  oldMax = arrayMax;
   uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
 
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, idx, arrayMax, newMax, op);
-  setArraySize(array2, idx, arrayMax, newMax, op);
+  setArraySize(array1, oldMax, arrayMax, newMax, op);
+  setArraySize(array2, oldMax, arrayMax, newMax, op);
 }
 
 
 template<typename T1, typename T2, typename T3, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, T3*& array3, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
+  uint64  oldMax = arrayMax;
   uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
 
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, idx, arrayMax, newMax, op);
-  setArraySize(array2, idx, arrayMax, newMax, op);
-  setArraySize(array3, idx, arrayMax, newMax, op);
+  setArraySize(array1, oldMax, arrayMax, newMax, op);
+  setArraySize(array2, oldMax, arrayMax, newMax, op);
+  setArraySize(array3, oldMax, arrayMax, newMax, op);
 }
 
 
 template<typename T1, typename T2, typename T3, typename T4, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, T3*& array3, T3*& array4, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
+  uint64  oldMax = arrayMax;
   uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
 
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, idx, arrayMax, newMax, op);
-  setArraySize(array2, idx, arrayMax, newMax, op);
-  setArraySize(array3, idx, arrayMax, newMax, op);
-  setArraySize(array4, idx, arrayMax, newMax, op);
+  setArraySize(array1, oldMax, arrayMax, newMax, op);
+  setArraySize(array2, oldMax, arrayMax, newMax, op);
+  setArraySize(array3, oldMax, arrayMax, newMax, op);
+  setArraySize(array4, oldMax, arrayMax, newMax, op);
 }
 
 
-//  Resize the array so that it is at least as big as new max.  Do nothing
-//  if the array is big enough already.
 
+//
+//  Ensure the array has at least 'newMax' elements:
+//    if arrayMax < newMax  ->  resize to newMax exactly.
+//    else                  ->  do nothing.
+//
+//  By default, new elements are not initialized, use
+//  _raAct::copyDataClearNew if desired.
+//
 template<typename TT, typename LL>
 void
 resizeArray(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op=_raAct::copyData) {

--- a/src/datastructures/arrays-v1.H
+++ b/src/datastructures/arrays-v1.H
@@ -223,7 +223,7 @@ increaseArray(TT*& array, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=
   if (idx < arrayMax)
     return;
 
-  setArraySize(array, arrayMax, arrayMax, newMax, op);
+  setArraySize(array, idx, arrayMax, newMax, op);
 }
 
 
@@ -235,8 +235,8 @@ increaseArrayPair(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 mor
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, arrayMax, arrayMax, newMax, op);
-  setArraySize(array2, arrayMax, arrayMax, newMax, op);
+  setArraySize(array1, idx, arrayMax, newMax, op);
+  setArraySize(array2, idx, arrayMax, newMax, op);
 }
 
 
@@ -248,8 +248,8 @@ increaseArray(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 moreSpa
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, arrayMax, arrayMax, newMax, op);
-  setArraySize(array2, arrayMax, arrayMax, newMax, op);
+  setArraySize(array1, idx, arrayMax, newMax, op);
+  setArraySize(array2, idx, arrayMax, newMax, op);
 }
 
 
@@ -261,9 +261,9 @@ increaseArray(T1*& array1, T2*& array2, T3*& array3, uint64 idx, LL &arrayMax, u
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, arrayMax, arrayMax, newMax, op);
-  setArraySize(array2, arrayMax, arrayMax, newMax, op);
-  setArraySize(array3, arrayMax, arrayMax, newMax, op);
+  setArraySize(array1, idx, arrayMax, newMax, op);
+  setArraySize(array2, idx, arrayMax, newMax, op);
+  setArraySize(array3, idx, arrayMax, newMax, op);
 }
 
 
@@ -275,10 +275,10 @@ increaseArray(T1*& array1, T2*& array2, T3*& array3, T3*& array4, uint64 idx, LL
   if (idx < arrayMax)
     return;
 
-  setArraySize(array1, arrayMax, arrayMax, newMax, op);
-  setArraySize(array2, arrayMax, arrayMax, newMax, op);
-  setArraySize(array3, arrayMax, arrayMax, newMax, op);
-  setArraySize(array4, arrayMax, arrayMax, newMax, op);
+  setArraySize(array1, idx, arrayMax, newMax, op);
+  setArraySize(array2, idx, arrayMax, newMax, op);
+  setArraySize(array3, idx, arrayMax, newMax, op);
+  setArraySize(array4, idx, arrayMax, newMax, op);
 }
 
 

--- a/src/datastructures/arrays-v1.H
+++ b/src/datastructures/arrays-v1.H
@@ -181,12 +181,11 @@ duplicateArray(TT*& to, LL &toLen, LL &toMax, TT const *fr, LL frLen, LL frMax=0
 //
 template<typename TT, typename LL>
 void
-setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op=_raAct::copyData) {
+setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op=_raAct::copyData, bool update=true) {
 
-  arrayMax =          newMax;
   arrayLen = std::min(newMax, arrayLen);
 
-  TT *copy = new TT [arrayMax];
+  TT *copy = new TT [newMax];
 
   if ((array != nullptr) &&
       (arrayLen > 0) &&
@@ -200,8 +199,11 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
 
   if ((op == _raAct::clearNew) ||
       (op == _raAct::copyDataClearNew))
-    for (uint32 ii=arrayLen; ii<arrayMax; ii++)
+    for (uint32 ii=arrayLen; ii<newMax; ii++)
       copy[ii] = TT();
+
+  if (update)
+    arrayMax = newMax;
 }
 
 
@@ -224,7 +226,7 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
 //  Likewise, for random-access, element arr[idx] is guaranteed to exist
 //  after the call:
 //
-//    idx = ...
+//    idx = arrMax + ...
 //    increaseArray(arr, idx, arrMax, 32)
 //    arr[idx] = ...
 //
@@ -240,75 +242,67 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
 //
 //  'moreSpace' must be at least 1.
 //
+
+static   //  Helper for increaseArray() -- return the first muliple of 'moreSpace'
+inline   //  that is strictly larger than 'idx'.
+uint64
+nmc(uint64 idx, uint64 moreSpace) {
+  uint64 ns = (moreSpace <= 1) ? (            (idx            ) + 1)
+                               : (moreSpace * (idx / moreSpace) + moreSpace);
+  assert(idx < ns);
+
+  return ns;
+}
+
 template<typename TT, typename LL>
 void
 increaseArray(TT*& array, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
-  uint64  oldMax = arrayMax;
-  uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
-
   if (idx < arrayMax)
     return;
-
-  setArraySize(array, oldMax, arrayMax, newMax, op);
+  setArraySize(array, arrayMax, arrayMax, nmc(idx, moreSpace), op);
 }
 
 
 template<typename T1, typename T2, typename LL>
 void
 increaseArrayPair(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
-  uint64  oldMax = arrayMax;
-  uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
-
   if (idx < arrayMax)
     return;
-
-  setArraySize(array1, oldMax, arrayMax, newMax, op);
-  setArraySize(array2, oldMax, arrayMax, newMax, op);
+  setArraySize(array1, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array2, arrayMax, arrayMax, nmc(idx, moreSpace), op);
 }
 
 
 template<typename T1, typename T2, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
-  uint64  oldMax = arrayMax;
-  uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
-
   if (idx < arrayMax)
     return;
-
-  setArraySize(array1, oldMax, arrayMax, newMax, op);
-  setArraySize(array2, oldMax, arrayMax, newMax, op);
+  setArraySize(array1, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array2, arrayMax, arrayMax, nmc(idx, moreSpace), op);
 }
 
 
 template<typename T1, typename T2, typename T3, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, T3*& array3, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
-  uint64  oldMax = arrayMax;
-  uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
-
   if (idx < arrayMax)
     return;
-
-  setArraySize(array1, oldMax, arrayMax, newMax, op);
-  setArraySize(array2, oldMax, arrayMax, newMax, op);
-  setArraySize(array3, oldMax, arrayMax, newMax, op);
+  setArraySize(array1, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array2, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array3, arrayMax, arrayMax, nmc(idx, moreSpace), op);
 }
 
 
 template<typename T1, typename T2, typename T3, typename T4, typename LL>
 void
 increaseArray(T1*& array1, T2*& array2, T3*& array3, T3*& array4, uint64 idx, LL &arrayMax, uint64 moreSpace, _raAct op=_raAct::copyData) {
-  uint64  oldMax = arrayMax;
-  uint64  newMax = idx + ((moreSpace == 0) ? 1 : moreSpace);
-
   if (idx < arrayMax)
     return;
-
-  setArraySize(array1, oldMax, arrayMax, newMax, op);
-  setArraySize(array2, oldMax, arrayMax, newMax, op);
-  setArraySize(array3, oldMax, arrayMax, newMax, op);
-  setArraySize(array4, oldMax, arrayMax, newMax, op);
+  setArraySize(array1, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array2, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array3, arrayMax, arrayMax, nmc(idx, moreSpace), op, false);
+  setArraySize(array4, arrayMax, arrayMax, nmc(idx, moreSpace), op);
 }
 
 

--- a/src/main.mk
+++ b/src/main.mk
@@ -200,6 +200,7 @@ SUBMAKEFILES := pccp/pccp.mk \
 ifeq ($(BUILDTESTS), 1)
 SUBMAKEFILES += tests/alignTest-ssw.mk \
                 tests/alignTest-ksw2.mk \
+                tests/arraysTest.mk \
                 tests/bitsTest.mk \
                 tests/commandAvailableTest.mk \
                 tests/decodeIntegerTest.mk \

--- a/src/tests/arraysTest.C
+++ b/src/tests/arraysTest.C
@@ -187,32 +187,33 @@ main(int32 argc, char **argv) {
 
   for (Clen=10000; Clen < 110000; Clen += 10000) {
     fprintf(stderr, "  step from %lu to %lu\n", Clen-10000, Clen);
+
     increaseArrayPair(C, D, Clen, Cmax, 3333, _raAct::copyDataClearNew);
+
     fprintf(stderr, "  step from %lu to %lu cmax now %u\n", Clen-10000, Clen, Cmax);
-  }
-  Clen -= 10000;  //  Last valid allocation!
 
-  assert(Clen <= Cmax);
+    assert(Clen <= Cmax);
 
-  fprintf(stderr, "  setting (Clen = %u)\n", Clen);
+    fprintf(stderr, "  setting (%u .. %u)\n", Clen-10000, Clen);
 
-  for (uint64 ii=0; ii<Clen; ii++) {
-    C[ii] = ii << 8;
-    D[ii] = ii << 16;
-  }
+    for (uint64 ii=Clen-10000; ii<Clen; ii++) {
+      C[ii] = ii << 8;
+      D[ii] = ii << 16;
+    }
 
-  fprintf(stderr, "  testing\n");
+    fprintf(stderr, "  testing\n");
 
-  for (uint64 ii=0; ii<Clen; ii++) {
-    assert(C[ii] == ii << 8);
-    assert(D[ii] == ii << 16);
-  }
+    for (uint64 ii=0; ii<Clen; ii++) {
+      assert(C[ii] == ii << 8);
+      assert(D[ii] == ii << 16);
+    }
 
-  fprintf(stderr, "  testing zero\n");
+    fprintf(stderr, "  testing zero\n");
 
-  for (uint64 ii=Clen; ii<Cmax; ii++) {
-    assert(C[ii] == 0);
-    assert(D[ii] == 0);
+    for (uint64 ii=Clen; ii<Cmax; ii++) {
+      assert(C[ii] == 0);
+      assert(D[ii] == 0);
+    }
   }
 
   delete [] A;  Amax = Alen = 0;  A = nullptr;

--- a/src/tests/arraysTest.C
+++ b/src/tests/arraysTest.C
@@ -27,91 +27,198 @@ int32
 main(int32 argc, char **argv) {
   uint32   Alen=0, Amax=0;   uint32  *A=nullptr;
   uint32   Blen=0, Bmax=0;   uint32  *B=nullptr;
-  uint32   Clen=0, Cmax=0;   uint32  *C=nullptr;
-  uint32   Dlen=0, Dmax=0;   uint32  *D=nullptr;
+  uint32   Clen=0, Cmax=0;   uint64  *C=nullptr;
+  uint32   Dlen=0, Dmax=0;   uint64  *D=nullptr;
 
   fprintf(stderr, "Testing increaseArray() and related.\n");
   fprintf(stderr, "For best results, run in valgrind.\n");
   fprintf(stderr, "\n");
-  fprintf(stderr, "Calling allocateArray().\n");
-
-  allocateArray(A, Amax, 4000);     //  Allocate new arrays, both will
-  allocateArray(B, Bmax = 4000);    //  set elements to zero by default.
-
-  for (uint32 ii=0; ii<4000; ii++)  //  Let valgrind check for overflow.
-    A[ii] = B[ii] = ii;
-
-  fprintf(stderr, "Testing allocateArray().\n");
-
-  for (uint32 ii=0; ii<4000; ii++) {
-    assert(A[ii] == ii);
-    assert(B[ii] == ii);
-  }
-
-  for (uint32 ii=0; ii<4000; ii++)  //  Let valgrind check for overflow.
-    A[ii] = ii << 8;
-
-  for (uint32 ii=0; ii<4000; ii++)
-    B[ii] = ii << 16;
-
-  Alen = 4000;   //  Set the length of the two arrays;
-  Blen = 4000;   //  necessary for duplicateArray() below!
 
   //
 
-  fprintf(stderr, "Calling duplicateArray().\n");
+  fprintf(stderr, "allocateArray()\n");
 
-  duplicateArray(C, Clen, Cmax, A, Alen, Amax);        //  Duplicate the arrays,
-  duplicateArray(D, Dlen, Dmax, B, Blen, Bmax);        //  the last call will force
-  duplicateArray(D, Dlen, Dmax, B, Blen, Bmax, true);  //  a reallocation.
+  allocateArray(A, Amax, 4000);       //  Allocate new arrays, both will
+  allocateArray(B, Bmax = 4000);      //  set elements to zero by default.
 
-  fprintf(stderr, "Testing duplicateArray().\n");
-  for (uint32 ii=0; ii<4000; ii++) {
-    assert(C[ii] == A[ii]);
-    assert(D[ii] == B[ii]);
-  }
+  fprintf(stderr, "  setting\n");
+
+  for (uint32 ii=0; ii<Amax; ii++)     A[ii] = ii << 8;
+  for (uint32 ii=0; ii<Bmax; ii++)     B[ii] = ii << 16;
+
+  fprintf(stderr, "  checking\n");
+
+  for (uint32 ii=0; ii<Amax; ii++)     assert(A[ii] == ii << 8);
+  for (uint32 ii=0; ii<Bmax; ii++)     assert(B[ii] == ii << 16);
+
+  fprintf(stderr, "  releasing\n");
+
+  delete [] A;  Amax = Alen = 0;  A = nullptr;
+  delete [] B;  Bmax = Blen = 0;  B = nullptr;
+  delete [] C;  Cmax = Clen = 0;  C = nullptr;
+  delete [] D;  Dmax = Dlen = 0;  D = nullptr;
+
+  //
+
+  fprintf(stderr, "increaseArray() from nullptr\n");
+
+  Alen = 3332;  increaseArray(A,    Alen, Amax, 3333, _raAct::copyDataClearNew);  assert(Amax == 3333);
+  Alen = 3333;  increaseArray(A,    Alen, Amax, 3333, _raAct::copyDataClearNew);  assert(Amax == 6666);
+  Blen = 3334;  increaseArray(B,    Blen, Bmax, 3333, _raAct::copyDataClearNew);  assert(Bmax == 6666);
+
+  Clen = 3332;  increaseArray(C, D, Clen, Cmax, 3333, _raAct::copyDataClearNew);  assert(Cmax == 3333);
+  Clen = 6667;  increaseArray(C, D, Clen, Cmax, 3333, _raAct::copyDataClearNew);  assert(Cmax == 9999);
+
+  fprintf(stderr, "  setting\n");
+
+  for (uint32 ii=0; ii<Alen; ii++)      A[ii] = ii << 8;
+  for (uint32 ii=0; ii<Blen; ii++)      B[ii] = ii << 16;
+  for (uint64 ii=0; ii<Clen; ii++)    { C[ii] = ii << 24;  D[ii] = ii << 32; }
+
+  fprintf(stderr, "  checking\n");
+
+  for (uint32 ii=0; ii<Alen; ii++)      assert(A[ii] == ii << 8);
+  for (uint32 ii=0; ii<Blen; ii++)      assert(B[ii] == ii << 16);
+  for (uint64 ii=0; ii<Clen; ii++)    { assert(C[ii] == ii << 24);
+                                        assert(D[ii] == ii << 32); }
+
+  for (uint32 ii=Alen; ii<Amax; ii++)   assert(A[ii] == 0);
+  for (uint32 ii=Blen; ii<Bmax; ii++)   assert(B[ii] == 0);
+  for (uint64 ii=Clen; ii<Cmax; ii++) { assert(C[ii] == 0);
+                                        assert(D[ii] == 0); }
+
+  fprintf(stderr, "  releasing\n");
+
+  //lete [] A;  Amax = Alen = 0;  A = nullptr;
+  delete [] B;  Bmax = Blen = 0;  B = nullptr;
+  //lete [] C;  Cmax = Clen = 0;  C = nullptr;
+  delete [] D;  Dmax = Dlen = 0;  D = nullptr;
+
+  //
+
+  fprintf(stderr, "duplicateArray() (lengths %u %u %u %u)\n", Alen, Blen, Clen, Dlen);
+
+  duplicateArray(B, Blen, Bmax, A, Alen, Amax);        //  Duplicate the arrays,
+  duplicateArray(D, Dlen, Dmax, C, Clen, Cmax);        //  the last call will force
+  duplicateArray(D, Dlen, Dmax, C, Clen, Cmax, true);  //  a reallocation.
+
+  assert(Blen == Alen);
+  assert(Bmax == Alen);
+
+  assert(Dlen == Clen);
+  assert(Dmax == Clen);
+
+  fprintf(stderr, "  checking\n");
+
+  for (uint32 ii=0; ii<Blen; ii++)  assert(B[ii] == A[ii]);
+  for (uint64 ii=0; ii<Dlen; ii++)  assert(D[ii] == C[ii]);
 
   //
 
   fprintf(stderr, "Testing increaseArray(single).\n");
 
-  for (uint32 ii=0; ii<6000; ii++) {
-    increaseArray(A, ii, Amax, 511, _raAct::copyDataClearNew);
+  Alen *= 2;
+  for (uint32 ii=0; ii<Alen; ii++) {
+    increaseArray(A, ii, Amax, 3333, _raAct::copyDataClearNew);
     A[ii] = ii;
   }
 
-  fprintf(stderr, "  Reallocated A from 4000 to 6000 with max %lu\n", Amax);
+  fprintf(stderr, "  Reallocated A from Alen=%u to Alen=%u, now with Amax %lu\n", Alen/2, Alen, Amax);
 
-  for (uint32 ii=0; ii<6000; ii++)
+  for (uint32 ii=0; ii<Alen; ii++)
     assert(A[ii] == ii);
-  for (uint32 ii=6000; ii<Amax; ii++)
+  for (uint32 ii=Alen; ii<Amax; ii++)
     assert(A[ii] == 0);
+
+  fprintf(stderr, "  releasing\n");
+
+  delete [] A;  Amax = Alen = 0;  A = nullptr;
+  delete [] B;  Bmax = Blen = 0;  B = nullptr;
+  delete [] C;  Cmax = Clen = 0;  C = nullptr;
+  delete [] D;  Dmax = Dlen = 0;  D = nullptr;
 
   //
 
   fprintf(stderr, "Testing increaseArray(pair).\n");
 
-  for (uint32 ii=0; ii<6000; ii++) {
-    increaseArrayPair(C, D, ii, Cmax, 511, _raAct::copyDataClearNew);
+  Clen *= 2;
+  for (uint64 ii=0; ii<Clen; ii++) {
+    increaseArrayPair(C, D, ii, Cmax, 3333, _raAct::copyDataClearNew);
     C[ii] = ii << 8;
     D[ii] = ii << 16;
+
+    //fprintf(stderr, "ii = %u %u %u -- %lu %lu\n", ii, ii << 8, ii << 16, C[ii], D[ii]);
+
+    //if (ii > 0) {
+    //  fprintf(stderr, "     %u %u %u -- %lu %lu\n", ii-1, (ii-1) << 8, (ii-1) << 16, C[ii-1], D[ii-1]);
+    //  assert(C[ii-1] == (ii-1) << 8);
+    //  assert(D[ii-1] == (ii-1) << 16);
+    //}
   }
 
-  fprintf(stderr, "  Reallocated C and D from 4000 to 6000 with max %lu\n", Cmax);
+  fprintf(stderr, "  Reallocated C and D from Clen=%u to Clen=%u, now with Cmax %lu\n", Clen/2, Clen, Cmax);
 
-  for (uint32 ii=0; ii<6000; ii++) {
+  for (uint64 ii=0; ii<Clen; ii++) {
     assert(C[ii] == ii << 8);
     assert(D[ii] == ii << 16);
   }
-  for (uint32 ii=6000; ii<Cmax; ii++) {
+
+  fprintf(stderr, "  testing zero\n");
+
+  for (uint64 ii=Clen; ii<Cmax; ii++) {
     assert(C[ii] == 0);
     assert(D[ii] == 0);
   }
 
-  delete [] A;
-  delete [] B;
-  delete [] C;
-  delete [] D;
+  delete [] A;  Amax = Alen = 0;  A = nullptr;
+  delete [] B;  Bmax = Blen = 0;  B = nullptr;
+  delete [] C;  Cmax = Clen = 0;  C = nullptr;
+  delete [] D;  Dmax = Dlen = 0;  D = nullptr;
+
+  //
+
+  fprintf(stderr, "Testing increaseArray(pair) zero.\n");
+
+  increaseArrayPair(C, D, 0, Cmax, 3333, _raAct::copyDataClearNew);
+  increaseArrayPair(C, D, 1, Cmax, 3333, _raAct::copyDataClearNew);
+  increaseArrayPair(C, D, 0, Cmax, 3333, _raAct::copyDataClearNew);
+
+  fprintf(stderr, "Testing increaseArray(pair) stepped.\n");
+
+  for (Clen=10000; Clen < 110000; Clen += 10000) {
+    fprintf(stderr, "  step from %lu to %lu\n", Clen-10000, Clen);
+    increaseArrayPair(C, D, Clen, Cmax, 3333, _raAct::copyDataClearNew);
+    fprintf(stderr, "  step from %lu to %lu cmax now %u\n", Clen-10000, Clen, Cmax);
+  }
+  Clen -= 10000;  //  Last valid allocation!
+
+  assert(Clen <= Cmax);
+
+  fprintf(stderr, "  setting (Clen = %u)\n", Clen);
+
+  for (uint64 ii=0; ii<Clen; ii++) {
+    C[ii] = ii << 8;
+    D[ii] = ii << 16;
+  }
+
+  fprintf(stderr, "  testing\n");
+
+  for (uint64 ii=0; ii<Clen; ii++) {
+    assert(C[ii] == ii << 8);
+    assert(D[ii] == ii << 16);
+  }
+
+  fprintf(stderr, "  testing zero\n");
+
+  for (uint64 ii=Clen; ii<Cmax; ii++) {
+    assert(C[ii] == 0);
+    assert(D[ii] == 0);
+  }
+
+  delete [] A;  Amax = Alen = 0;  A = nullptr;
+  delete [] B;  Bmax = Blen = 0;  B = nullptr;
+  delete [] C;  Cmax = Clen = 0;  C = nullptr;
+  delete [] D;  Dmax = Dlen = 0;  D = nullptr;
 
   return(0);
 }

--- a/src/tests/arraysTest.C
+++ b/src/tests/arraysTest.C
@@ -1,0 +1,117 @@
+
+/******************************************************************************
+ *
+ *  This file is part of meryl-utility, a collection of miscellaneous code
+ *  used by Meryl, Canu and others.
+ *
+ *  This software is based on:
+ *    'Canu' v2.0              (https://github.com/marbl/canu)
+ *  which is based on:
+ *    'Celera Assembler' r4587 (http://wgs-assembler.sourceforge.net)
+ *    the 'kmer package' r1994 (http://kmer.sourceforge.net)
+ *
+ *  Except as indicated otherwise, this is a 'United States Government Work',
+ *  and is released in the public domain.
+ *
+ *  File 'README.licenses' in the root directory of this distribution
+ *  contains full conditions and disclaimers.
+ */
+
+#include "types.H"
+#include "arrays.H"
+
+using namespace merylutil;
+
+
+int32
+main(int32 argc, char **argv) {
+  uint32   Alen=0, Amax=0;   uint32  *A=nullptr;
+  uint32   Blen=0, Bmax=0;   uint32  *B=nullptr;
+  uint32   Clen=0, Cmax=0;   uint32  *C=nullptr;
+  uint32   Dlen=0, Dmax=0;   uint32  *D=nullptr;
+
+  fprintf(stderr, "Testing increaseArray() and related.\n");
+  fprintf(stderr, "For best results, run in valgrind.\n");
+  fprintf(stderr, "\n");
+  fprintf(stderr, "Calling allocateArray().\n");
+
+  allocateArray(A, Amax, 4000);     //  Allocate new arrays, both will
+  allocateArray(B, Bmax = 4000);    //  set elements to zero by default.
+
+  for (uint32 ii=0; ii<4000; ii++)  //  Let valgrind check for overflow.
+    A[ii] = B[ii] = ii;
+
+  fprintf(stderr, "Testing allocateArray().\n");
+
+  for (uint32 ii=0; ii<4000; ii++) {
+    assert(A[ii] == ii);
+    assert(B[ii] == ii);
+  }
+
+  for (uint32 ii=0; ii<4000; ii++)  //  Let valgrind check for overflow.
+    A[ii] = ii << 8;
+
+  for (uint32 ii=0; ii<4000; ii++)
+    B[ii] = ii << 16;
+
+  Alen = 4000;   //  Set the length of the two arrays;
+  Blen = 4000;   //  necessary for duplicateArray() below!
+
+  //
+
+  fprintf(stderr, "Calling duplicateArray().\n");
+
+  duplicateArray(C, Clen, Cmax, A, Alen, Amax);        //  Duplicate the arrays,
+  duplicateArray(D, Dlen, Dmax, B, Blen, Bmax);        //  the last call will force
+  duplicateArray(D, Dlen, Dmax, B, Blen, Bmax, true);  //  a reallocation.
+
+  fprintf(stderr, "Testing duplicateArray().\n");
+  for (uint32 ii=0; ii<4000; ii++) {
+    assert(C[ii] == A[ii]);
+    assert(D[ii] == B[ii]);
+  }
+
+  //
+
+  fprintf(stderr, "Testing increaseArray(single).\n");
+
+  for (uint32 ii=0; ii<6000; ii++) {
+    increaseArray(A, ii, Amax, 511, _raAct::copyDataClearNew);
+    A[ii] = ii;
+  }
+
+  fprintf(stderr, "  Reallocated A from 4000 to 6000 with max %lu\n", Amax);
+
+  for (uint32 ii=0; ii<6000; ii++)
+    assert(A[ii] == ii);
+  for (uint32 ii=6000; ii<Amax; ii++)
+    assert(A[ii] == 0);
+
+  //
+
+  fprintf(stderr, "Testing increaseArray(pair).\n");
+
+  for (uint32 ii=0; ii<6000; ii++) {
+    increaseArrayPair(C, D, ii, Cmax, 511, _raAct::copyDataClearNew);
+    C[ii] = ii << 8;
+    D[ii] = ii << 16;
+  }
+
+  fprintf(stderr, "  Reallocated C and D from 4000 to 6000 with max %lu\n", Cmax);
+
+  for (uint32 ii=0; ii<6000; ii++) {
+    assert(C[ii] == ii << 8);
+    assert(D[ii] == ii << 16);
+  }
+  for (uint32 ii=6000; ii<Cmax; ii++) {
+    assert(C[ii] == 0);
+    assert(D[ii] == 0);
+  }
+
+  delete [] A;
+  delete [] B;
+  delete [] C;
+  delete [] D;
+
+  return(0);
+}

--- a/src/tests/arraysTest.mk
+++ b/src/tests/arraysTest.mk
@@ -1,0 +1,8 @@
+TARGET   := arraysTest
+SOURCES  := arraysTest.C
+
+SRC_INCDIRS := .. ../utility
+
+TGT_LDFLAGS := -L${TARGET_DIR}/lib
+TGT_LDLIBS  := -l${MODULE}
+TGT_PREREQS := lib${MODULE}.a


### PR DESCRIPTION
Second parameter is the size of current array which gets reset to new size, causing a segfault in the second call to setArraySize when copying old data over to new array.