### PR TITLE
Changed uint32 loop var to uint64 to prevent overflow for very long scaffolds

### DIFF
--- a/src/datastructures/arrays-v1.H
+++ b/src/datastructures/arrays-v1.H
@@ -191,7 +191,7 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
       (arrayLen > 0) &&
       ((op == _raAct::copyData) ||
        (op == _raAct::copyDataClearNew)))
-    for (uint32 ii=0; ii<arrayLen; ii++)
+    for (uint64 ii=0; ii<arrayLen; ii++)
       copy[ii] = array[ii];
 
   delete [] array;
@@ -199,7 +199,7 @@ setArraySize(TT*& array, uint64 arrayLen, LL &arrayMax, uint64 newMax, _raAct op
 
   if ((op == _raAct::clearNew) ||
       (op == _raAct::copyDataClearNew))
-    for (uint32 ii=arrayLen; ii<newMax; ii++)
+    for (uint64 ii=arrayLen; ii<newMax; ii++)
       copy[ii] = TT();
 
   if (update)


### PR DESCRIPTION
For scaffolds longer than 32-bit (~4.3 gigabases) the uint32 loop variables overflow, and have been observed to cause code to hang. Changing the variables to uint64 fixes this. 